### PR TITLE
[김민경] fix: User의 Shop 타입 수정

### DIFF
--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -2,16 +2,11 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import axiosInstance from '@/api/settings/axiosInstance';
 import { jwtDecode } from 'jwt-decode';
 import { useRouter } from 'next/router';
+import { Shop } from '@/types/shop';
 
-interface Shop {
-	id: string;
-	name: string;
-	category: string;
-	address1: string;
-	address2: string;
-	description: string;
-	imageUrl: string;
-	originalHourlyPay: number;
+interface ShopItem {
+	item: Shop;
+	href: string;
 }
 
 interface User {
@@ -22,7 +17,7 @@ interface User {
 	phone?: string;
 	address?: string;
 	bio?: string;
-	shop?: Shop | null;
+	shop?: ShopItem | null;
 }
 
 interface UserContextType {


### PR DESCRIPTION
api로 받아오는 user 정보에서 shop 데이터가 아래와 같음.

{
    "item": {
        "id": "9dc161a7-ffa6-4c47-b810-e6b25c1f4689",
        "name": "애슐리퀸즈",
        "category": "양식",
        "address1": "서울시 강동구",
        "address2": "천호동",
        "description": "천호역 3번 출구에서 도보 5분 거리에 위치한 뉴코아 팩토리 아울렛 천호점 4층에 있습니다.",
        "imageUrl": "https://bootcamp-project-api.s3.ap-northeast-2.amazonaws.com/16-05/the-julge/2bc00c2f-b5ea-4c04-9279-7d1bdcbe78d8-2025-08-01T09-30-07-562Z_%EC%95%A0%EC%8A%90%EB%A6%AC.jpeg",
        "originalHourlyPay": "10000"
    },
    "href": "/api/16-05/the-julge/shops/9dc161a7-ffa6-4c47-b810-e6b25c1f4689"
}